### PR TITLE
Skip UI phone number selection if provided by CLI flag

### DIFF
--- a/plugin-dev-phone-client/src/App.js
+++ b/plugin-dev-phone-client/src/App.js
@@ -36,6 +36,14 @@ function App() {
 
   useEffect(() => {
     setupKonamiCode();
+
+    fetch("/plugin-settings")
+      .then((res) => res.json())
+      .then((settings) => {
+        if (settings.phoneNumber) {
+          setDevPhonePn(settings.phoneNumber);
+        }
+      })
   }, []);
 
   return (
@@ -49,6 +57,7 @@ function App() {
         :
         <PhoneNumberPicker setDevPhonePn={setDevPhonePn}/>
       }
+
 
     </div>
   );

--- a/plugin-dev-phone-client/src/components/SendSmsForm.js
+++ b/plugin-dev-phone-client/src/components/SendSmsForm.js
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+const formatPnForForm = pn => `${pn.phoneNumber} [${pn.friendlyName}]`
+
 function SendSmsForm({ devPhonePn, sendSms }) {
 
     const [toPn, setToPn] = useState(null);
@@ -15,7 +17,7 @@ function SendSmsForm({ devPhonePn, sendSms }) {
             <input
                 id="sendSmsFromPn"
                 disabled={true}
-                value={devPhonePn.phoneNumber}
+                value={formatPnForForm(devPhonePn)}
                 />
 
             <label htmlFor="sendSmsToPn">To</label>

--- a/plugin-dev-phone/src/commands/dev-phone.js
+++ b/plugin-dev-phone/src/commands/dev-phone.js
@@ -99,7 +99,7 @@ class DevPhoneServer extends TwilioClientCommand {
                 );
             }
 
-            this.cliSettings.phoneNumber = flags['phone-number'];
+            this.cliSettings.phoneNumber = reformatTwilioPns(this.pns)["phone-numbers"][0];
         }
     }
 


### PR DESCRIPTION
If a user specifies the `--phone-number` CLI flag we can skip the
step in the UI where they choose a phone number.

This commit also adds the friendlyName for the PN to the
/plugin-settings endpoint as we're already calling the Twilio CLI
to validate the number this doesn't cost anything and makes the
friendly name available to the UI.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
