### PR TITLE
Fixes shutdown behaviour

### DIFF
--- a/plugin-dev-phone/src/commands/dev-phone.js
+++ b/plugin-dev-phone/src/commands/dev-phone.js
@@ -68,7 +68,7 @@ class DevPhoneServer extends TwilioClientCommand {
         }
 
         process.on('SIGINT', async function () {
-            console.log("Shutting down");
+            console.log("\n👋 Shutting down");
             await onShutdown();
 
             process.exit();


### PR DESCRIPTION
Because the function passed to `process.on('SIGINT'...)` is
in its own scope we couldn't call this.someFunction directly.

This commit creates a function which closes over `this` which
can then be called inside the `process.on` function and will
take `this` with it so we can tidy up the user's account when
the plugin stops.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
