### PR TITLE
Terminal log improvement and friendlyName bugfix

### DIFF
--- a/plugin-dev-phone/src/commands/dev-phone.js
+++ b/plugin-dev-phone/src/commands/dev-phone.js
@@ -129,7 +129,7 @@ class DevPhoneServer extends TwilioClientCommand {
         })
 
         app.listen(PORT, () => {
-            console.log('🚀 Your local webserver is listening on port ${PORT}');
+            console.log(`🚀 Your local webserver is listening on port ${PORT}`);
             console.log('▶️  Use ctrl-c to stop your dev-phone');
         });
     }


### PR DESCRIPTION
If there isn't a pending dev-phone for deletion, the log won't show the deletion message at the start.

Also, there was a bugfix about `item.friendlyName` that needed to check the object and then use `startsWith` method.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
