### PR TITLE
Fixes console.error warnings from Paste

### DIFF
--- a/plugin-dev-phone-client/src/App.js
+++ b/plugin-dev-phone-client/src/App.js
@@ -59,15 +59,14 @@ function App() {
   return (
     <Grid padding="space30">
       <Column span={12}>
-        <Flex vAlignContent={true}>
+        <Flex>
           <Flex>
-            <Box padding="space40" backgroundColor="colorBackgroundDarker">
-              <Heading as="h1">Twilio dev-phone</Heading>
+            <Box padding="space40">
+              <Heading as="h1" variant="heading20">Twilio dev-phone</Heading>
             </Box>
           </Flex>
           <Flex grow>
             <Box
-              backgroundColor="colorBackgroundDarker"
               padding="space40"
               width="100%"
             >

--- a/plugin-dev-phone-client/src/components/Caller.js
+++ b/plugin-dev-phone-client/src/components/Caller.js
@@ -60,11 +60,12 @@ function Caller({ devPhonePn }) {
 
     return (
         <Stack orientation="vertical" spacing="space60">
-            <Heading as="h2">Who you gonna call? 👻</Heading>
+            <Heading as="h2" variant="heading20">Who you gonna call? 👻</Heading>
 
             <Stack orientation="vertical">
                 <Label htmlFor="calleePn" required>To</Label>
                 <Input
+                    type="text"
                     id="calleePn"
                     placeholder="E.164 format please"
                     defaultValue={calleePn}

--- a/plugin-dev-phone-client/src/components/PhoneNumberPicker.js
+++ b/plugin-dev-phone-client/src/components/PhoneNumberPicker.js
@@ -7,7 +7,8 @@ import {
   Option,
   Select,
   Stack,
-  Alert
+  Alert,
+  Text,
 } from "@twilio-paste/core";
 
 const hasExistingSmsConfig = (pn) => {
@@ -70,7 +71,7 @@ function PhoneNumberPicker({ setDevPhonePn }) {
     return (
       <Stack orientation="vertical" spacing="space60">
 
-        <Heading as="h2">Choose a phone number for this dev-phone</Heading>
+        <Heading as="h2" variant="heading20">Choose a phone number for this dev-phone</Heading>
 
         <Stack orientation="vertical">
           <Label htmlFor="devPhonePn" required>
@@ -91,23 +92,23 @@ function PhoneNumberPicker({ setDevPhonePn }) {
         </Stack>
 
         {chosenPn ? (
-          <div className="pnConfirm">
+          <Stack orientation="vertical" spacing="space60">
             {hasExistingConfig(chosenPn) ? (
-              <div>
+              <Stack orientation="vertical" spacing="space30">
                 <Alert variant="warning">
                   This phone number has existing config which will be overwritten
                 </Alert>
                 {hasExistingSmsConfig(chosenPn) ? (
-                  <div>Configured SMS URL: {chosenPn.smsUrl}</div>
+                  <Text >Configured SMS URL: <em>{chosenPn.smsUrl}</em></Text>
                 ) : (
                   ""
                 )}
                 {hasExistingVoiceConfig(chosenPn) ? (
-                  <div>Configured Voice URL: {chosenPn.voiceUrl}</div>
+                  <Text>Configured Voice URL: <em>{chosenPn.voiceUrl}</em></Text>
                 ) : (
                   ""
                 )}
-              </div>
+              </Stack>
             ) : (
               ""
             )}
@@ -115,7 +116,7 @@ function PhoneNumberPicker({ setDevPhonePn }) {
             <Button variant="primary" onClick={(e) => setDevPhonePn(chosenPn)}>
               Use this phone number
             </Button>
-          </div>
+          </Stack>
         ) : (
           ""
         )}

--- a/plugin-dev-phone-client/src/components/SendSmsForm.js
+++ b/plugin-dev-phone-client/src/components/SendSmsForm.js
@@ -12,11 +12,12 @@ function SendSmsForm({ devPhonePn, sendSms }) {
   return (
     <Stack orientation="vertical" spacing="space60">
 
-      <Heading as="h2">SMS messaging</Heading>
+      <Heading as="h2" variant="heading20">SMS messaging</Heading>
 
       <Stack orientation="vertical">
         <Label htmlFor="sendSmsToPn" required>To</Label>
         <Input
+          type="text"
           id="sendSmsToPn"
           placeholder="E.164 format please"
           defaultValue={toPn}


### PR DESCRIPTION
These caused by
 - using deprecated properties
 - not supplying some mandatory properties
in components.

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
