### PR TITLE
Use longer-lived AccessTokens by default

### DIFF
--- a/plugin-dev-phone/src/commands/dev-phone.js
+++ b/plugin-dev-phone/src/commands/dev-phone.js
@@ -286,7 +286,8 @@ class DevPhoneServer extends TwilioClientCommand {
             this.apikey.sid,
             this.apikey.secret,
             {
-                identity: this.devPhoneName
+                identity: this.devPhoneName,
+                ttl: 24*60*60
             }
         );
 


### PR DESCRIPTION
Bump up the TTL (time-to-live) value for Access Tokens we create. The
default is 3600 seconds (one hour), this changes it to 24 * 60 * 60 seconds
(24 hours).

This is a band-aid style fix because the correct solution is to be
hooking into one of the client callbacks for `tokenAboutToExpire` and
generating a new one transparently to the user. But that might be quite
a big fix, and perhaps we can live with this as a known limitation for
Tweek.

See Issue #51

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
