### PR TITLE
fix: force flag default

### DIFF
--- a/plugin-dev-phone/src/commands/dev-phone.js
+++ b/plugin-dev-phone/src/commands/dev-phone.js
@@ -367,7 +367,6 @@ class DevPhoneServer extends TwilioClientCommand {
             });
     }
 
-
     async createJwt() {
 
         const chatGrant = new ChatGrant({
@@ -475,7 +474,6 @@ DevPhoneServer.PropertyFlags = {
     }),
     force: flags.boolean({
         char: 'f',
-        default: false,
         description: 'Force the phone number configuration to be overwritten',
         dependsOn: ['phone-number']
     })


### PR DESCRIPTION
**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
