### PR TITLE
Ignore sourcemap warnings

### DIFF
--- a/plugin-dev-phone-client/prod.webpack.config.js
+++ b/plugin-dev-phone-client/prod.webpack.config.js
@@ -50,6 +50,7 @@ module.exports = {
             ]
           }]
     },
+    ignoreWarnings: [/Failed to parse source map/],
     resolve: {
         extensions: ['*', '.js', '.jsx'],
         fallback: {


### PR DESCRIPTION
Ignore warnings for missing sourcemaps in Twilio audiohelper library

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
