### PR TITLE
Use redux devtools extension

### DIFF
--- a/plugin-dev-phone-client/package.json
+++ b/plugin-dev-phone-client/package.json
@@ -9,7 +9,9 @@
   },
   "author": "twilio-labs",
   "license": "ISC",
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "devDependencies": {
     "@babel/core": "^7.17.5",
     "@babel/plugin-transform-react-jsx": "^7.17.3",
@@ -35,6 +37,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "redux": "^4.1.2",
+    "redux-devtools-extension": "^2.13.9",
     "redux-thunk": "^2.4.1",
     "twilio-sync": "^3.0.6",
     "util": "^0.12.4"

--- a/plugin-dev-phone-client/src/index.js
+++ b/plugin-dev-phone-client/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { Provider } from 'react-redux'
 import { compose, createStore, applyMiddleware} from 'redux'
 import thunk from 'redux-thunk'
+import { composeWithDevTools } from 'redux-devtools-extension';
 import reducer from './reducer'
 import { fetchChannelData, fetchClientToken } from './actions'
 import "./index.css";
@@ -11,9 +12,8 @@ import App from "./components/App/App";
 import { Theme } from "@twilio-paste/core/theme";
 
 /* TODO: make devtools conditional on dev environment */
-const store = createStore(reducer, compose(
-  applyMiddleware(thunk),
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+const store = createStore(reducer, composeWithDevTools(
+  applyMiddleware(thunk)
 ))
 
 store.dispatch(fetchClientToken())


### PR DESCRIPTION
Replaces the explicit reference to redux devtools with the devtools extension. This should now work in "prod" or dev, regardless of whether the user has devtools enabled.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
