### PR TITLE
feat(ui): add welcome dialog and revamp picker

### DIFF
--- a/plugin-dev-phone-client/src/components/PhoneNumberPicker/PhoneNumberPicker.jsx
+++ b/plugin-dev-phone-client/src/components/PhoneNumberPicker/PhoneNumberPicker.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 
-import { Box, Button, Heading, Label, Option, Select, Stack, Alert, Text, SkeletonLoader } from "@twilio-paste/core";
+import { Anchor, Box, Button, Heading, Label, Option, Select, Stack, Alert, Text, SkeletonLoader, Paragraph, Card } from "@twilio-paste/core";
+import WelcomeDialog from "./WelcomeDialog";
 
 const hasExistingSmsConfig = (pn) => {
   return pn.smsUrl && pn.smsUrl !== "https://demo.twilio.com/welcome/sms/reply";
@@ -31,12 +32,26 @@ const sortUnconfiguredNumbersFirstThenAlphabetically = (pn1, pn2) => {
   return pn1.phoneNumber.localeCompare(pn2.phoneNumber);
 };
 
+function PhoneNumberPickerContainer({ children }) {
+  return <Box
+    maxWidth={"75%"}
+    margin={"auto"}
+    marginY={"space120"}
+    padding={"space120"}
+    backgroundColor={"colorBackgroundBody"}
+    boxShadow={"shadow"}
+    borderRadius={"borderRadius20"}
+  >
+    {children}
+  </Box>
+}
+
 function PhoneNumberPicker({ configureNumberInUse, phoneNumbers }) {
   const [twilioPns, setTwilioPns] = useState(null);
   const [selectedPn, setSelectedPn] = useState(null);
 
-  useEffect(async() => {
-    if(!selectedPn) {
+  useEffect(async () => {
+    if (!selectedPn) {
       try {
         const response = await fetch('/phone-numbers')
         const data = await response.json()
@@ -56,26 +71,37 @@ function PhoneNumberPicker({ configureNumberInUse, phoneNumbers }) {
         console.error(error)
       }
     }
-        
+
   }, [selectedPn]);
-  
+
   if (twilioPns === null) {
-    return (<SkeletonLoader height={"size50"}/>)
+    return (<SkeletonLoader height={"size50"} />)
   } else if (twilioPns.length === 0) {
     return (
-      <Box backgroundColor={"colorBackgroundBody"}>
-        <Text as="p">I couldn't find any phone numbers on your account!</Text>
-        <Anchor
-          href="https://support.twilio.com/hc/en-us/articles/223135247-How-to-Search-for-and-Buy-a-Twilio-Phone-Number-from-Console"
-          target="_blank"
-        >Please purchase a phone number to get started. :)</Anchor>
-      </Box>
-      )
+      <PhoneNumberPickerContainer>
+        <WelcomeDialog />
+        <Stack orientation={"vertical"}>
+          <Box width="200px" as="img" src="https://paste.twilio.design/images/patterns/empty-no-results-found.png" alt="" />
+          <Heading as="h2" variant="heading20">Could not find any phone numbers.</Heading>
+          <Paragraph>In order to use the Dev Phone you'll need to have a Twilio Phone Number. Once you purchased a phone number you can refresh this page to get started.</Paragraph>
+          <Button
+            as="a"
+            href="https://support.twilio.com/hc/en-us/articles/223135247-How-to-Search-for-and-Buy-a-Twilio-Phone-Number-from-Console"
+            target="_blank"
+          >Purchase a phone number to get started.</Button>
+        </Stack>
+      </PhoneNumberPickerContainer>
+    )
   } else {
     return (
-      <Box backgroundColor={"colorBackgroundBody"} padding={"space120"}>
-        <Heading as="h2" variant="heading20">Choose a phone number for this dev-phone</Heading>
+      <PhoneNumberPickerContainer>
+        <WelcomeDialog />
         <Stack orientation="vertical">
+          <Heading as="h2" variant="heading20">Select a phone number</Heading>
+          <Paragraph>
+            Pick one of the phone numbers from your Twilio account to configure your Dev Phone. This phone number will be the one to send messages and make calls.
+            Any calls and text messages sent to this number will show up in the Dev Phone.
+          </Paragraph>
           <Label htmlFor="devPhonePn" required>
             Phone number
           </Label>
@@ -122,7 +148,7 @@ function PhoneNumberPicker({ configureNumberInUse, phoneNumbers }) {
         ) : (
           ""
         )}
-      </Box>
+      </PhoneNumberPickerContainer>
     );
   }
 }

--- a/plugin-dev-phone-client/src/components/PhoneNumberPicker/WelcomeDialog.jsx
+++ b/plugin-dev-phone-client/src/components/PhoneNumberPicker/WelcomeDialog.jsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Anchor, Box, Button, Heading, Flex, Label, Option, Select, Stack, Alert, Text, SkeletonLoader, Paragraph, Card } from "@twilio-paste/core";
+import SuccessIllustration from "../Illustrations/SuccessIllustration";
+
+const LOCAL_STORAGE_KEY = 'DEV_PHONE_HIDE_WELCOME';
+
+function WelcomeDialog() {
+  const [showWelcomeDialog, setShowWelcomeDialog] = useState(!(localStorage.getItem(LOCAL_STORAGE_KEY) === 'true'));
+
+  function dismiss() {
+    localStorage.setItem(LOCAL_STORAGE_KEY, 'true');
+    setShowWelcomeDialog(false);
+  }
+
+  if (!showWelcomeDialog) {
+    return null;
+  }
+
+  return <Box marginBottom={"space120"}>
+    <Card>
+      <Stack orientation={"vertical"} spacing={"space40"}>
+        <SuccessIllustration />
+        <Heading as="h2" variant="heading20">Welcome to the Dev Phone</Heading>
+        <Paragraph>
+          The Dev Phone is your friendly companion when building Twilio applications.
+          You can use this tool to test the behavior of your Twilio applications without having to grab your personal phone
+          or when your cell phone coverage is giving up on you.
+        </Paragraph>
+        <Paragraph>
+          This tool is a Twilio Labs project meaning it is <em>not</em> covered by Twilio Support. If you find any issues, want to look under the hood, or even contribute to the tool,
+          the project is 100% open-source and <Anchor href="https://github.com/twilio-labs/dev-phone" showExternal>available on GitHub</Anchor>.
+        </Paragraph>
+        <Paragraph>
+          <strong>We can't wait to see what you build!</strong>
+        </Paragraph>
+        <Flex hAlignContent={"between"} vAlignContent="center">
+          <Button as="a" variant="secondary" href="https://www.twilio.com/docs/labs/dev-phone">Read the docs</Button>
+          <Button onClick={dismiss} variant="link">Don't show this again.</Button>
+        </Flex>
+      </Stack>
+    </Card>
+  </Box>
+}
+
+export default WelcomeDialog;


### PR DESCRIPTION
<!-- Describe your Pull Request -->

I streamlined the phone number picker to use the same formatting as the SoftPhone component. I also added a Welcome component that customers see but can dismiss at which point it's not shown anymore as long as the LocalStorage remains.

**Note**: The docs and GitHub links don't work since we haven't set those up yet. We should also host the second illustration ourselves.

Here are some screenshots of both views with and without the welcome dialog.

<img width="721" alt="Screen Shot 2022-03-09 at 15 54 20" src="https://user-images.githubusercontent.com/1505101/157559659-25ad443c-7629-4aa7-b739-a23875a46977.png">
<img width="763" alt="Screen Shot 2022-03-09 at 15 53 58" src="https://user-images.githubusercontent.com/1505101/157559662-7144543a-8e5c-4222-85bd-d24de1af234f.png">
<img width="771" alt="Screen Shot 2022-03-09 at 15 53 53" src="https://user-images.githubusercontent.com/1505101/157559664-d78dfc0e-9015-4032-9960-b7dd47f1e3b6.png">
<img width="689" alt="Screen Shot 2022-03-09 at 15 53 22" src="https://user-images.githubusercontent.com/1505101/157559670-b5fd2a07-1d23-40f6-9425-769b7297db11.png">

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
