### PR TITLE
Remove <Say> from inbound and outbound calls

### DIFF
--- a/packages/dev-phone/src/serverless/functions/incoming-call-handler.js
+++ b/packages/dev-phone/src/serverless/functions/incoming-call-handler.js
@@ -3,7 +3,6 @@
 exports.handler = function(context, event, callback) {
     let twiml = new Twilio.twiml.VoiceResponse();
 
-    twiml.say(`Hello! I'm connecting you to your dev phone...`);
     const dial = twiml.dial();
     dial.client(context.DEV_PHONE_NAME);
 

--- a/packages/dev-phone/src/serverless/functions/outbound-call-handler.js
+++ b/packages/dev-phone/src/serverless/functions/outbound-call-handler.js
@@ -6,9 +6,6 @@ exports.handler = function(context, event, callback) {
     if (!event.from || !event.to) {
         return callback('You need to provide From and To params', null);
     }
-
-    twiml.say(`Hello! I'm connecting you to the phone...`);
-
     const dial = twiml.dial({
         callerId: event.from,
     });


### PR DESCRIPTION
Removes <Say> Verbs to make calling experience quicker and more phone-like

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
