### PR TITLE
Add version details to dev phone and pass them to serverless functions

### DIFF
--- a/packages/dev-phone/src/commands/dev-phone.ts
+++ b/packages/dev-phone/src/commands/dev-phone.ts
@@ -8,6 +8,9 @@ import { deployServerless, constants } from '../utils/create-serverless-util';
 import { isSmsUrlSet, isVoiceUrlSet } from '../phone-number-utils';
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
+const { version } = require('../../package.json');
+
+console.log('package version is', version)
 
 // Types
 import { ServiceInstance as ServerlessServiceInstance } from 'twilio/lib/rest/serverless/v1/service'
@@ -224,6 +227,7 @@ class DevPhoneServer extends TwilioClientCommand {
                 CONVERSATION_SID: this.conversation.sid,
                 CONVERSATION_SERVICE_SID: this.conversation.serviceSid,
                 DEV_PHONE_NAME: this.devPhoneName,
+                DEV_PHONE_VERSION: version,
                 CALL_LOG_MAP_NAME
             }
         });

--- a/packages/dev-phone/src/serverless/functions/incoming-message-handler.js
+++ b/packages/dev-phone/src/serverless/functions/incoming-message-handler.js
@@ -3,7 +3,12 @@
 exports.handler = async function(context, event, callback) {
     // receive an SMS and put into a conversation
 
-    const client = context.getTwilioClient();
+    const client = context.getTwilioClient({
+        userAgentExtension: [
+            `@twilio-labs/plugin-dev-phone/${context.DEV_PHONE_VERSION}`, 
+            'serverless-functions'
+        ]
+    });
     await client.conversations
         .services(context.CONVERSATION_SERVICE_SID)
         .conversations(context.CONVERSATION_SID)

--- a/packages/dev-phone/src/serverless/functions/outbound-call-handler.js
+++ b/packages/dev-phone/src/serverless/functions/outbound-call-handler.js
@@ -13,7 +13,6 @@ exports.handler = function(context, event, callback) {
         statusCallback: `https://${context.DOMAIN_NAME}/sync-call-history`,
         statusCallbackEvent: 'initiated ringing answered completed'
     }, event.to);
-    console.log(twiml.toString());
 
     return callback(null, twiml);
 };

--- a/packages/dev-phone/src/serverless/functions/sync-call-history.js
+++ b/packages/dev-phone/src/serverless/functions/sync-call-history.js
@@ -1,5 +1,10 @@
 async function updateCallStatusFromEvent(context, callSid, data) {
-    const client = context.getTwilioClient();
+    const client = context.getTwilioClient({
+        userAgentExtension: [
+            `@twilio-labs/plugin-dev-phone/${context.DEV_PHONE_VERSION}`, 
+            'serverless-functions'
+        ]
+    });
     try {
         return await client.sync
             .services(context.SYNC_SERVICE_SID)

--- a/packages/dev-phone/src/utils/create-serverless-util.ts
+++ b/packages/dev-phone/src/utils/create-serverless-util.ts
@@ -19,7 +19,8 @@ interface devPhoneServerlessConfig {
         CONVERSATION_SID: string,
         CONVERSATION_SERVICE_SID: string,
         DEV_PHONE_NAME: string,
-        CALL_LOG_MAP_NAME: string
+        CALL_LOG_MAP_NAME: string,
+        DEV_PHONE_VERSION: string
     },
     onUpdate?: (event: deployEvent) => void
 }
@@ -80,6 +81,6 @@ export async function deployServerless(context: devPhoneServerlessConfig) {
         return result;
     } catch (err) {
         console.log(err);
-        throw new Error('Something went wrong. Try again later');
+        throw new Error('Issue deploying functions. Try again later');
     }
 }


### PR DESCRIPTION
Add in version number and tracking information to functions calls. Solves half of the places where we'd like to add user agent strings, with the other location being in the CLI Client.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
