### PR TITLE
Oclif v2

### DIFF
--- a/.changeset/serious-mice-exist.md
+++ b/.changeset/serious-mice-exist.md
@@ -1,0 +1,5 @@
+---
+"@twilio-labs/plugin-dev-phone": minor
+---
+
+The dev phone plugin is now compatible with Twilio CLI v5. Backwards compatibility is no longer guaranteed, unfortunately, so we recommend bumping to a recent node version and updating the plugin CLI as soon as possible.

--- a/packages/plugin-dev-phone/README.md
+++ b/packages/plugin-dev-phone/README.md
@@ -18,13 +18,36 @@ Once it's installed, you can run the Dev Phone with the following command:
 
 Check out the [Dev Phone documentation](https://www.twilio.com/docs/labs/dev-phone) to learn more about installing and using the Dev Phone.
 
-### Flags
+## Commands
+<!-- commands -->
+* [`twilio dev-phone`](#twilio-dev-phone)
 
-| Flag Name | Description |
-| --phone-number | Optional. Associates the Dev Phone with a phone number. Takes a number from the active profile on the Twilio CLI as the parameter.|
-| --force | Optional. Forces an overwrite of the phone number configuration. |
-| --headless | Optional. Prevents the UI from automatically opening in the browser. |
-| --port | Optional. Configures the port of the Dev Phone UI. Takes a valid port as a parameter. |
+## `twilio dev-phone`
+
+Dev Phone local express server
+
+```
+USAGE
+  $ twilio dev-phone [-l debug|info|warn|error|none] [-o columns|json|tsv|none] [--silent] [-p <value>] [-f
+    --phone-number <value>] [--headless] [--port <value>]
+
+FLAGS
+  -f, --force                      Optional. Forces an overwrite of the phone number configuration.
+  -l=(debug|info|warn|error|none)  [default: info] Level of logging messages.
+  -o=(columns|json|tsv|none)       [default: columns] Format of command output.
+  -p, --profile=<value>            Shorthand identifier for your profile.
+  --headless                       Optional. Prevents the UI from automatically opening in the browser.
+  --phone-number=<value>           Optional. Associates the Dev Phone with a phone number. Takes a number from the
+                                   active profile on the Twilio CLI as the parameter.
+  --port=<value>                   Optional. Configures the port of the Dev Phone UI. Takes a valid port as a parameter.
+  --silent                         Suppress  output and logs. This is a shorthand for "-l none -o none".
+
+DESCRIPTION
+  Dev Phone local express server
+```
+
+_See code: [dist/commands/dev-phone.ts](https://github.com/twilio-labs/dev-phone/blob/1.0.0-beta.2/dist/commands/dev-phone.ts)_
+<!-- commandsstop -->
  
 ## Working on this plugin
 

--- a/packages/plugin-dev-phone/package.json
+++ b/packages/plugin-dev-phone/package.json
@@ -10,7 +10,7 @@
     "@twilio-labs/dev-phone-ui": "^1.0.0-beta.1",
     "@oclif/core": "^1.13.6",
     "@twilio-labs/serverless-api": "^5.4.0",
-    "@twilio/cli-core": "^6.0.0",
+    "@twilio/cli-core": "^7.0.0",
     "express": "^4.17.1",
     "get-port": "^5.1.1",
     "open": "^8.4.0"

--- a/packages/plugin-dev-phone/package.json
+++ b/packages/plugin-dev-phone/package.json
@@ -7,9 +7,8 @@
     "url": "https://github.com/twilio-labs/dev-phone/issues"
   },
   "dependencies": {
-    "@oclif/command": "^1.5.20",
-    "@oclif/config": "^1.15.1",
     "@twilio-labs/dev-phone-ui": "^1.0.0-beta.1",
+    "@oclif/core": "^1.13.6",
     "@twilio-labs/serverless-api": "^5.4.0",
     "@twilio/cli-core": "^6.0.0",
     "express": "^4.17.1",
@@ -17,10 +16,10 @@
     "open": "^8.4.0"
   },
   "devDependencies": {
-    "@oclif/dev-cli": "^1.22.2",
     "@oclif/test": "^1.2.5",
     "@twilio/cli-test": "^2.1.0",
     "@types/express": "^4.17.13",
+    "@types/open": "^6.2.1",
     "chai": "^4.2.0",
     "eslint": "^8.3.0",
     "eslint-config-oclif": "^3.1.0",

--- a/packages/plugin-dev-phone/src/commands/dev-phone.ts
+++ b/packages/plugin-dev-phone/src/commands/dev-phone.ts
@@ -322,8 +322,8 @@ class DevPhoneServer extends TwilioClientCommand {
         // Flags defined below can be validated and used here. Example:
         // https://github.com/twilio/plugin-debugger/blob/main/src/commands/debugger/logs/list.js#L46-L56
 
-        this.port = process.env.TWILIO_DEV_PHONE_PORT || await getAvailablePort();
         this.cliSettings.forceMode = flags['force'];
+        this.port = process.env.TWILIO_DEV_PHONE_PORT || await getAvailablePort();
         if (flags['phone-number']) {
             this.pns = await this.twilioClient.incomingPhoneNumbers
                 .list({ phoneNumber: flags['phone-number'] });

--- a/packages/plugin-dev-phone/src/commands/dev-phone.ts
+++ b/packages/plugin-dev-phone/src/commands/dev-phone.ts
@@ -325,12 +325,13 @@ class DevPhoneServer extends TwilioClientCommand {
         this.cliSettings.forceMode = flags['force'];
         this.port = process.env.TWILIO_DEV_PHONE_PORT || await getAvailablePort();
         if (flags['phone-number']) {
+            const phoneNumber = await flags['phone-number']
             this.pns = await this.twilioClient.incomingPhoneNumbers
-                .list({ phoneNumber: flags['phone-number'] });
+                .list({ phoneNumber: phoneNumber });
 
             if (this.pns.length < 1) {
                 throw new TwilioCliError(
-                    `The phone number ${flags['phone-number']} is not associated with your Twilio account`
+                    `The phone number ${phoneNumber} is not associated with your Twilio account`
                 );
             }
 
@@ -341,7 +342,7 @@ class DevPhoneServer extends TwilioClientCommand {
 
             if (pnConfigAlreadySet.length > 0 && !this.cliSettings.forceMode) {
                 throw new TwilioCliError(
-                    `Cannot use ${flags['phone-number']} because the following config for that phone number would be overwritten: ` + pnConfigAlreadySet.join(", ")
+                    `Cannot use ${phoneNumber} because the following config for that phone number would be overwritten: ` + pnConfigAlreadySet.join(", ")
                 );
             }
 
@@ -350,12 +351,13 @@ class DevPhoneServer extends TwilioClientCommand {
         }
 
         if(flags['port']) {
+            const port = await flags['port']
             try {
-                if(isValidPort(flags['port'])){
-                    this.port = parseInt(flags['port'])
+                if(isValidPort(port)){
+                    this.port = parseInt(port)
                 } else {
                     throw new TwilioCliError(
-                        `❗️ '${flags['port']}' is not a valid port. 😳 I'll try to get set up with ${this.port} instead.`,
+                        `❗️ '${port}' is not a valid port. 😳 I'll try to get set up with ${this.port} instead.`,
                         )
                 }
             } catch (err:any) {

--- a/packages/plugin-dev-phone/src/commands/dev-phone.ts
+++ b/packages/plugin-dev-phone/src/commands/dev-phone.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import open from 'open';
 import express from 'express';
 
-import { flags } from '@oclif/command';
+import { Flags } from '@oclif/core';
 import { deployServerless, constants } from '../utils/create-serverless-util';
 import { getAvailablePort, isValidPort } from '../utils/helpers'
 import { isSmsUrlSet, isVoiceUrlSet } from '../utils/phone-number-utils';
@@ -585,19 +585,19 @@ DevPhoneServer.description = `Dev Phone local express server`
 // Example of how to define flags and properties:
 // https://github.com/twilio/plugin-debugger/blob/main/src/commands/debugger/logs/list.js#L99-L126
 DevPhoneServer.PropertyFlags = {
-    "phone-number": flags.string({
+    "phone-number": Flags.string({
         description: 'Optional. Associates the Dev Phone with a phone number. Takes a number from the active profile on the Twilio CLI as the parameter.'
     }),
-    force: flags.boolean({
+    force: Flags.boolean({
         char: 'f',
         description: 'Optional. Forces an overwrite of the phone number configuration.',
         dependsOn: ['phone-number']
     }),
-    headless: flags.boolean({
+    headless: Flags.boolean({
         description: 'Optional. Prevents the UI from automatically opening in the browser.',
         default: false,
     }),
-    port: flags.string({
+    port: Flags.string({
         description: 'Optional. Configures the port of the Dev Phone UI. Takes a valid port as a parameter.',
     })
 };


### PR DESCRIPTION
Update to use `@oclif/core` and make some flags appropriately async.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
