### PR TITLE
fix white spaces issue in message bubbles

### DIFF
--- a/packages/dev-phone-ui/src/components/SendSmsForm/MessageBubble.jsx
+++ b/packages/dev-phone-ui/src/components/SendSmsForm/MessageBubble.jsx
@@ -18,6 +18,7 @@ function MessageBubble({ devPhoneName, message }) {
           borderRadius="borderRadius20"
           borderTopRightRadius="borderRadius0"
           fontSize="fontSize30"
+          whiteSpace="pre-wrap"
           lineHeight="lineHeight20"
           padding="space30"
           maxWidth="size30"


### PR DESCRIPTION
The message bubbles in the chat history weren't able to display white spaces properly.

Before:

![Screen Shot 2022-09-29 at 14 58 05](https://user-images.githubusercontent.com/1873245/193042862-d7cf3fae-0277-4b82-b9ca-9104d7a57dca.png)

After:

![Screen Shot 2022-09-29 at 14 58 00](https://user-images.githubusercontent.com/1873245/193042871-7a03914c-e99a-4764-82e6-42a69e0383f2.png)


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
