### PR TITLE
Added maxHeight for call history Box

### DIFF
--- a/.changeset/selfish-oranges-knock.md
+++ b/.changeset/selfish-oranges-knock.md
@@ -1,0 +1,5 @@
+---
+"@twilio-labs/dev-phone-ui": patch
+---
+
+Fixed Overflow in Call History Component

--- a/packages/dev-phone-ui/src/components/CallHistory/CallHistory.jsx
+++ b/packages/dev-phone-ui/src/components/CallHistory/CallHistory.jsx
@@ -50,7 +50,7 @@ function CallHistory() {
 }, [addCallRecord, setSyncClient, syncClient, twilioAccessToken, updateCallRecord]);
 
   return (
-    <Box spacing="space30" backgroundColor={"colorBackground"} height={"100%"} borderRightWidth={"borderWidth10"} borderRightColor={"colorBorder"} borderRightStyle={"solid"}>
+    <Box spacing="space30" backgroundColor={"colorBackground"} maxHeight={"size80"} height={"100%"} borderRightWidth={"borderWidth10"} borderRightColor={"colorBorder"} borderRightStyle={"solid"}>
         <Flex vertical vAlignContent={"bottom"} height={"100%"}>
             <Box width={"100%"} padding={"space80"} overflowY={'scroll'} overflowX={'hidden'}>
               {callLog.length > 0 ?


### PR DESCRIPTION
<!-- Describe your Pull Request -->

Fixes #145 

Added `maxHeight` to `Box` component. 

`size80` is the same height being used in the Parent component `Softphone`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ ] I acknowledge that all my contributions will be made under the project's license.
