### PR TITLE
Add mute button

### DIFF
--- a/.changeset/smooth-trains-shout.md
+++ b/.changeset/smooth-trains-shout.md
@@ -1,0 +1,5 @@
+---
+"@twilio-labs/dev-phone-ui": minor
+---
+
+Added mute button to dialer for calls

--- a/packages/dev-phone-ui/src/actions/index.js
+++ b/packages/dev-phone-ui/src/actions/index.js
@@ -43,6 +43,14 @@ export function updateCallInformation(call) {
     }
 }
 
+export const UPDATE_MUTE_STATUS = "UPDATE_MUTE_STATUS";
+
+export function updateMuteStatus(isMuted) {
+    return {
+        type: UPDATE_MUTE_STATUS,
+        isMuted
+    }
+}
 
 // Logic for communicating with the local backend
 export const DEV_PHONE_NUMBER_SELECTED = "DEV_PHONE_NUMBER_SELECTED"

--- a/packages/dev-phone-ui/src/components/Dialer/Dialer.jsx
+++ b/packages/dev-phone-ui/src/components/Dialer/Dialer.jsx
@@ -1,6 +1,8 @@
 import { useContext, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux'
-import { Button, Flex, Stack, Grid, Column, Box } from "@twilio-paste/core";
+import { Button, Flex, Stack, Grid, Column, Box, ScreenReaderOnly } from "@twilio-paste/core";
+import { MicrophoneOnIcon } from "@twilio-paste/icons/cjs/MicrophoneOnIcon";
+import { MicrophoneOffIcon } from "@twilio-paste/icons/cjs/MicrophoneOffIcon";
 import { TwilioVoiceContext } from '../WebsocketManagers/VoiceManager';
 import DTMFButton from './DtmfButton';
 import { addDigitToDestinationNumber } from '../../actions';
@@ -9,6 +11,7 @@ import CallStatusMessage from './StatusMessage';
 function Dialer() {
     const currentCallInfo = useSelector((state) => state.currentCallInfo)
     const destinationNumber = useSelector(state => state.destinationNumber)
+    const isMuted = useSelector(state => state.isMuted)
     const dispatch = useDispatch();
 
     const dialer = useContext(TwilioVoiceContext)
@@ -24,6 +27,10 @@ function Dialer() {
 
     function hangUp() {
         dialer.hangUp()
+    }
+
+    function toggleMute() {
+        dialer.toggleMute();
     }
 
     function sendDTMF(num) {
@@ -51,7 +58,16 @@ function Dialer() {
         <Box width="100%" paddingTop="space60">
             <Stack orientation="vertical" spacing="space60">
                 <Box width="100%">
-                    <CallStatusMessage voiceDevice={voiceDevice} currentCallInfo={currentCallInfo} />
+                    <Flex>
+                        <Flex grow hAlignContent={"center"}>
+                            <CallStatusMessage voiceDevice={voiceDevice} currentCallInfo={currentCallInfo} />
+                        </Flex>
+                        <Flex>
+                            { isCallInProgress && <Button variant="secondary_icon" size="reset" onClick={toggleMute}>
+                                {!isMuted ? <MicrophoneOnIcon size="sizeIcon20" title="Mute" decorative={false}/> : <MicrophoneOffIcon size="sizeIcon20" title="Mute" decorative={false} />}
+                            </Button> }
+                        </Flex>
+                    </Flex>
                     <Flex>
                         {generateDTMFColumn(['1', '2', '3'])}
                     </Flex>

--- a/packages/dev-phone-ui/src/components/WebsocketManagers/VoiceManager.jsx
+++ b/packages/dev-phone-ui/src/components/WebsocketManagers/VoiceManager.jsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useState, useEffect, useRef} from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { Device } from '@twilio/voice-sdk'
-import { updateCallInformation } from '../../actions'
+import { updateCallInformation, updateMuteStatus } from '../../actions'
 
 // Establish context with relevant websocket resources for child components
 const TwilioVoiceContext = React.createContext(null)
@@ -17,6 +17,10 @@ const TwilioVoiceManager = ({ children }) => {
 
     const updateCallInfo = useCallback((call) => {
         dispatch(updateCallInformation(call))
+    }, [dispatch])
+
+    const updateIsMutedStatus = useCallback((isMuted) => {
+        dispatch(updateMuteStatus(isMuted))
     }, [dispatch])
 
     // responsible for making calls with Twilio Voice SDK
@@ -53,6 +57,15 @@ const TwilioVoiceManager = ({ children }) => {
                 activeCall.sendDigits(num);
             }
 
+            deviceDetails.current.toggleMute = () => {
+                 console.log('activeCall', activeCall);
+                if (!activeCall) {
+                    return;
+                }
+                console.log('isMuted', activeCall.isMuted());
+                activeCall.mute(!activeCall.isMuted());
+            }
+
             activeCall.on('accept', call => {
                 updateCallInfo(call)
             })
@@ -64,6 +77,10 @@ const TwilioVoiceManager = ({ children }) => {
             activeCall.on('disconnect', call => {
                 call.removeAllListeners()
                 updateCallInfo(null)
+            })
+
+            activeCall.on('mute', isMuted => {
+                updateIsMutedStatus(isMuted);
             })
         }
     }, [activeCall, updateCallInfo])
@@ -96,7 +113,8 @@ const TwilioVoiceManager = ({ children }) => {
             hangUp: () => {},
             sendDTMF: () => {},
             updateCallInfo,
-            makeCall
+            makeCall,
+            toggleMute: () => {}
         }
     }
 

--- a/packages/dev-phone-ui/src/reducer/index.js
+++ b/packages/dev-phone-ui/src/reducer/index.js
@@ -9,6 +9,7 @@ import {
     ADD_CALL_RECORD,
     UPDATE_CALL_RECORD,
     UPDATE_CALL_INFORMATION,
+    UPDATE_MUTE_STATUS,
     SET_DESTINATION_NUMBER,
     ADD_DIGIT_TO_DESTINATION_NUMBER
 } from '../actions'
@@ -58,6 +59,11 @@ export default function reducer(state = initialState, action) {
             return { ...state, destinationNumber: action.number }
         case UPDATE_CALL_INFORMATION:
             return { ...state, currentCallInfo: action.call ? { ...state.currentCallInfo, ...action.call } : null }
+        case UPDATE_MUTE_STATUS:
+            return {
+                ...state,
+                isMuted: action.isMuted
+            }
         case ADD_DIGIT_TO_DESTINATION_NUMBER:
             return { ...state, destinationNumber: state.destinationNumber + action.digit }
         default:


### PR DESCRIPTION
<!-- Describe your Pull Request -->

There was no way to mute a call that was happening with the Dev Phone which made trying applications harder that required proxying between two phones. This change adds a mute button that shows up when the call is in progress.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
