### PR TITLE
fix(Webpack): Set default proxy target 1337

### DIFF
--- a/packages/dev-phone-ui/webpack.config.js
+++ b/packages/dev-phone-ui/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
         },
         proxy: {
             '**': {
-                target: 'http://localhost:3001',
+                target: 'http://localhost:1337',
                 bypass: (req) => (req.headers.accept.includes("html") ? "/" : null)
             },
         },


### PR DESCRIPTION
## Change default proxy target in webpack configuration 

As describe in the issue #181 , sets the default proxy target so the dev-phone-ui can run out of the box.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
