### PR TITLE
Deleting resources using the dev phone name

### DIFF
--- a/.changeset/metal-students-invite.md
+++ b/.changeset/metal-students-invite.md
@@ -1,0 +1,5 @@
+---
+"@twilio-labs/plugin-dev-phone": patch
+---
+
+Use the Dev Phone Name when deleting resources to allow multiple instances to work against the same subaccount.

--- a/packages/plugin-dev-phone/src/commands/dev-phone.ts
+++ b/packages/plugin-dev-phone/src/commands/dev-phone.ts
@@ -270,7 +270,7 @@ class DevPhoneServer extends TwilioClientCommand {
         })
 
         if(devPhoneFunctionServices.length > 0) {
-            console.log('🚮 Removing existing dev phone Serverless Functions');
+            console.log(`🚮 Removing Serverless Functions for ${this.devPhoneName}`);
             devPhoneFunctionServices.forEach(async (functionService: ServerlessServiceInstance) => {
                 await this.twilioClient.serverless.services(functionService.sid)
                         .remove();
@@ -391,7 +391,7 @@ class DevPhoneServer extends TwilioClientCommand {
                 })
                 
                 if(devPhoneKeys.length > 0) {
-                    console.log('🚮 Removing existing dev phone API Keys');
+                    console.log(`🚮 Removing API Keys for ${this.devPhoneName}`);
                     devPhoneKeys.forEach(async (key: KeyInstance) => {
                         await this.twilioClient.keys(key.sid).remove();
                     })
@@ -426,7 +426,7 @@ class DevPhoneServer extends TwilioClientCommand {
             })
 
             if(devPhoneApps.length > 0) {
-                console.log('🚮 Removing existing dev phone TwiML apps');
+                console.log(`🚮 Removing TwiML app for ${this.devPhoneName}`);
                 devPhoneApps.forEach(async (twimlApp: ApplicationInstance) => {
                     await this.twilioClient.applications(twimlApp.sid)
                         .remove();
@@ -494,7 +494,7 @@ class DevPhoneServer extends TwilioClientCommand {
             })
             
             if(devPhoneSyncServices.length > 0) {
-                console.log('🚮 Removing existing dev phone Sync Services');
+                console.log(`🚮 Removing Sync Service for ${this.devPhoneName}`);
                 devPhoneSyncServices.forEach(async (syncService: SyncServiceInstance) => {
                     await this.twilioClient.sync.services(syncService.sid)
                             .remove();
@@ -534,7 +534,7 @@ class DevPhoneServer extends TwilioClientCommand {
             })
             
             if(devPhoneConvoServices.length > 0) {
-                console.log('🚮 Removing existing dev phone Conversation Services');
+                console.log(`🚮 Removing Conversation Service for ${this.devPhoneName}`);
                 devPhoneConvoServices.forEach(async (convoService: ConversationServiceInstance) => {
                     await this.twilioClient.conversations.services(convoService.sid)
                             .remove();

--- a/packages/plugin-dev-phone/src/commands/dev-phone.ts
+++ b/packages/plugin-dev-phone/src/commands/dev-phone.ts
@@ -266,7 +266,7 @@ class DevPhoneServer extends TwilioClientCommand {
         try {
             const functionServices = await this.twilioClient.serverless.services.list()
             const devPhoneFunctionServices = functionServices.filter((functionServices: ServerlessServiceInstance) => {
-            return functionServices.friendlyName !== null && functionServices.friendlyName.startsWith('dev-phone')
+            return functionServices.friendlyName !== null && functionServices.friendlyName.startsWith(this.devPhoneName)
         })
 
         if(devPhoneFunctionServices.length > 0) {
@@ -387,7 +387,7 @@ class DevPhoneServer extends TwilioClientCommand {
             try {
                 const keys = await this.twilioClient.keys.list()
                 const devPhoneKeys = keys.filter((key: KeyInstance) => {
-                    return key.friendlyName !== null && key.friendlyName.startsWith('dev-phone')
+                    return key.friendlyName !== null && key.friendlyName.startsWith(this.devPhoneName)
                 })
                 
                 if(devPhoneKeys.length > 0) {
@@ -422,7 +422,7 @@ class DevPhoneServer extends TwilioClientCommand {
         try {
             const applications = await this.twilioClient.applications.list()
             const devPhoneApps = applications.filter((twimlApp: ApplicationInstance) => {
-                return twimlApp.friendlyName !== null && twimlApp.friendlyName.startsWith('dev-phone')
+                return twimlApp.friendlyName !== null && twimlApp.friendlyName.startsWith(this.devPhoneName)
             })
 
             if(devPhoneApps.length > 0) {
@@ -490,7 +490,7 @@ class DevPhoneServer extends TwilioClientCommand {
         try {
             const syncServices = await this.twilioClient.sync.services.list()
             const devPhoneSyncServices = syncServices.filter((syncService: SyncServiceInstance) => {
-                return syncService.friendlyName !== null && syncService.friendlyName.startsWith('dev-phone')
+                return syncService.friendlyName !== null && syncService.friendlyName.startsWith(this.devPhoneName)
             })
             
             if(devPhoneSyncServices.length > 0) {
@@ -511,7 +511,7 @@ class DevPhoneServer extends TwilioClientCommand {
         console.log('💻 Creating a new conversation...');
         try {
             const service = await this.twilioClient.conversations.services
-                .create({ friendlyName: 'dev-phone' });
+                .create({ friendlyName: this.devPhoneName });
             const conversationService = this.twilioClient.conversations.services(service.sid)
             const newConversation = await conversationService.conversations.create({ friendlyName: this.devPhoneName })
             await conversationService.conversations(newConversation.sid)
@@ -530,7 +530,7 @@ class DevPhoneServer extends TwilioClientCommand {
         try {
             const convoServices = await this.twilioClient.conversations.services.list()
             const devPhoneConvoServices = convoServices.filter((convoService: SyncServiceInstance) => {
-                return convoService.friendlyName !== null && convoService.friendlyName.startsWith('dev-phone')
+                return convoService.friendlyName !== null && convoService.friendlyName.startsWith(this.devPhoneName)
             })
             
             if(devPhoneConvoServices.length > 0) {


### PR DESCRIPTION
Addresses https://github.com/twilio-labs/dev-phone/issues/36 partially.

On destroying, instead of deleting all dev-phone resources, target only those created for the instance been used.
This way we can run the dev-phone from multiple locations and working in parallel.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [ x ] I acknowledge that all my contributions will be made under the project's license.
