### PR TITLE
Remove loglevel from voice manager

### DIFF
--- a/.changeset/polite-ties-occur.md
+++ b/.changeset/polite-ties-occur.md
@@ -1,0 +1,5 @@
+---
+"@twilio-labs/dev-phone-ui": patch
+---
+
+Remove logging from Voice SDK component, which was causing errors on startup

--- a/packages/dev-phone-ui/src/components/WebsocketManagers/VoiceManager.jsx
+++ b/packages/dev-phone-ui/src/components/WebsocketManagers/VoiceManager.jsx
@@ -91,8 +91,7 @@ const TwilioVoiceManager = ({ children }) => {
             codecPreferences: ["opus", "pcmu"],
             fakeLocalDTMF: true,
             debug: false,
-            enableRingingState: true,
-            logLevel: '1'
+            enableRingingState: true
         })
 
 


### PR DESCRIPTION
Bugfix to remove loglevel from the voice manager.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
